### PR TITLE
Remove NumberStyles and CultureInfo from double parsing.

### DIFF
--- a/src/Dds/Services/StoreService.cs
+++ b/src/Dds/Services/StoreService.cs
@@ -152,7 +152,7 @@ namespace Geta.DdsAdmin.Dds.Services
             if (typeConverter is DoubleConverter)
             {
                 double value;
-                if (double.TryParse(stringValue, out value))
+                if (double.TryParse(stringValue.Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture.NumberFormat, out value))
                 {
                     return value;
                 }

--- a/src/Dds/Services/StoreService.cs
+++ b/src/Dds/Services/StoreService.cs
@@ -152,7 +152,7 @@ namespace Geta.DdsAdmin.Dds.Services
             if (typeConverter is DoubleConverter)
             {
                 double value;
-                if (double.TryParse(stringValue, NumberStyles.Any, CultureInfo.InvariantCulture.NumberFormat, out value))
+                if (double.TryParse(stringValue, out value))
                 {
                     return value;
                 }


### PR DESCRIPTION
Had to remove it since this formatting of the double removed any commas from the double value, thus rendering it useless for usage in for example longitude or latitude values